### PR TITLE
Fixed bulk write operation with Motor 2.0

### DIFF
--- a/nyuki/workflow/db/task_templates.py
+++ b/nyuki/workflow/db/task_templates.py
@@ -1,7 +1,6 @@
 import logging
 
-from pymongo import ASCENDING, DESCENDING
-from pymongo import ReplaceOne
+from pymongo import ASCENDING, DESCENDING, ReplaceOne
 from pymongo.errors import BulkWriteError
 
 from .utils.indexes import check_index_names


### PR DESCRIPTION
Use `MotorCollection.bulk_write` instead of deprecated `MotorCollection.initialize_unordered_bulk_op` to insert multiple tasks at once.